### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,11 +15,10 @@
       Woodland Hills, CA, U.S.A.
     </div>
   </header>
+ 
   <nav class="site-nav">
     <ul>
       <li><a href="google.html" title="Google Support">Google Issues Mailing List</a></li>
-      <li><a href="#">Network Neutrality Squad</a></li>
-      <li><a href="#">Lauren Weinstein's Blog</a></li>
       <li><a href="forum.html" title="Privacy Forum">The PRIVACY Forum</a></li>
     </ul>
   </nav>


### PR DESCRIPTION
Getting rid of Network Neutrality Squad and Lauren Weinstein's Blog, since the pages no longer exist.